### PR TITLE
🚸 expose server on host IP

### DIFF
--- a/Nikto/challenge-nikto.md
+++ b/Nikto/challenge-nikto.md
@@ -6,6 +6,6 @@ trouver le numéro OSVDB de la potentielle vulnérabilité de la machine docker 
 ## Que faut-il faire ?
 * Récupérer la machine sur docker hub : 
     * ```docker pull tanguybron/nikto```
-    * ```docker run -it -p 80 tanguybron/nikto```
+    * ```docker run -it -p 80:80 --name niktoSrv tanguybron/nikto```
 
 * Analyser la machine avec nikto et lire le numéro OSVDB de la vulnérabilité trouvée.


### PR DESCRIPTION
cette méthode évite de connaitre l'IP du conteneur.